### PR TITLE
updates for derecho

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -941,6 +941,9 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">ncarcompilers/1.0.0</command>
         <command name="load">cmake</command>
       </modules>
+      <modules mpilib="impi">
+	<command name="load">impi/2021.8.0</command>
+      </modules>
       <modules mpilib="mpich">
 	<command name="load">cray-mpich/8.1.25</command>
       </modules>
@@ -962,13 +965,14 @@ This allows using a different mpirun command to launch unit tests
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>  
-      <env name="MPICH_MPIIO_STATS">1</env>
-      <env name="MPICH_MPIIO_HINTS_DISPLAY">1</env>
+      <!--      <env name="MPICH_MPIIO_STATS">1</env>
+           <env name="MPICH_MPIIO_HINTS_DISPLAY">1</env> -->
+      <env name="MPICH_COLL_SYNC">1</env>
     </environment_variables>
-<!--    <environment_variables mpilib="mpich">
-      <env name="MPICH_MPIIO_HINTS">*:romio_cb_read=enable:romio_cb_write=enable:striping_factor=2</env>
+    <environment_variables mpilib="mpich">
+      <env name="MPICH_MPIIO_HINTS">*:romio_cb_read=enable:romio_cb_write=enable:striping_factor=24</env>
     </environment_variables>
--->
+    
   </machine>
 
   <machine MACH="edison">

--- a/src/externals/pio1/pio/box_rearrange.F90.in
+++ b/src/externals/pio1/pio/box_rearrange.F90.in
@@ -1662,19 +1662,18 @@ end subroutine box_rearrange_io2comp_{TYPE}
 
     endif
 
+    if(associated(iodesc%stype) .and. associated(iodesc%scount)) then
 
-    do i=1,Iosystem%num_iotasks
-       if (ioDesc%scount(i) /= 0) then
-          call MPI_TYPE_FREE(ioDesc%stype(i), ierror)
-          call CheckMPIReturn(subName,ierror)
-       endif
-    end do
+       do i=1,Iosystem%num_iotasks
+          if (ioDesc%scount(i) /= 0) then
+             call MPI_TYPE_FREE(ioDesc%stype(i), ierror)
+             call CheckMPIReturn(subName,ierror)
+          endif
+       end do
 
-    if(associated(iodesc%scount)) then
        call dealloc_check(ioDesc%scount)
        nullify(iodesc%scount)
-    end if
-    if(associated(iodesc%stype)) then
+
        call dealloc_check(ioDesc%stype,'iodesc%stype')
        nullify(iodesc%stype)
     end if

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -132,7 +132,7 @@ contains
        call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
        Global_COMM=mpicom
 
-       print *,__FILE__,__LINE__,subname, ' complete'
+!       print *,__FILE__,__LINE__,subname, ' complete'
 #endif
     end if
     total_comps = ncomps
@@ -189,19 +189,19 @@ contains
     allocate(iosystems(total_comps))
 
     if(pio_async_interface) then
-       call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
-       do i=1,total_comps
-         ret =  pio_set_rearr_opts(iosystems(i), pio_rearr_opt_comm_type,&
-                  pio_rearr_opt_fcd,&
-                  pio_rearr_opt_c2i_enable_hs, pio_rearr_opt_c2i_enable_isend,&
-                  pio_rearr_opt_c2i_max_pend_req,&
-                  pio_rearr_opt_i2c_enable_hs, pio_rearr_opt_i2c_enable_isend,&
-                  pio_rearr_opt_i2c_max_pend_req)
-         if(ret /= PIO_NOERR) then
+!       call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
+!       do i=1,total_comps
+!         ret =  pio_set_rearr_opts(iosystems(i), pio_rearr_opt_comm_type,&
+!                  pio_rearr_opt_fcd,&
+!                  pio_rearr_opt_c2i_enable_hs, pio_rearr_opt_c2i_enable_isend,&
+!                  pio_rearr_opt_c2i_max_pend_req,&
+!                  pio_rearr_opt_i2c_enable_hs, pio_rearr_opt_i2c_enable_isend,&
+!                  pio_rearr_opt_i2c_max_pend_req)
+!         if(ret /= PIO_NOERR) then
             write(shr_log_unit,*) "ERROR: Setting rearranger options failed"
-         end if
-       end do
-       i=1
+!         end if
+!       end do
+!       i=1
     else
        do i=1,total_comps
           if(comp_iamin(i)) then
@@ -216,6 +216,7 @@ contains
                   pio_comp_settings(i)%pio_root, pio_comp_settings(i)%pio_numiotasks, &
                   pio_comp_settings(i)%pio_iotype, pio_comp_settings(i)%pio_rearranger, &
                   pio_comp_settings(i)%pio_netcdf_ioformat)
+!             print *,__FILE__,__LINE__,i,pio_comp_settings(i)%pio_stride
              call pio_init(comp_comm_iam(i), comp_comm(i), pio_comp_settings(i)%pio_numiotasks, 0, &
                   pio_comp_settings(i)%pio_stride, &
                   pio_comp_settings(i)%pio_rearranger, iosystems(i), &


### PR DESCRIPTION
The env variable MPICH_MPIIO_STATS=1 was causing hangs and even incorrect file writes.
I have removed this along with a few other minor changes. 